### PR TITLE
Need jaxb-api dependency for java 8+ version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,5 +186,10 @@
 			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Got jaxb exception when used java 8+ version
Why need jaxb-api in java 8+ ?
https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j

I faced exception with following java and maven version
C:\Users>java -version
java version "10.0.1" 2018-04-17
Java(TM) SE Runtime Environment 18.3 (build 10.0.1+10)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.1+10, mixed mode)

C:\Users>mvn -v
Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-25T01:19:0
5+05:30)
Maven home: C:\Program Files\apache-maven-3.5.3\bin\..
Java version: 1.8.0_172, vendor: Oracle Corporation
Java home: C:\Program Files\Java\jdk1.8.0_172\jre
Default locale: en_IN, platform encoding: Cp1252
OS name: "windows 8.1", version: "6.3", arch: "amd64", family: "windows"

After adding jaxb api, I am able to run application.