### PR TITLE
changing JWT secret key to random string

### DIFF
--- a/src/main/java/com/app/identity/TokenUtil.java
+++ b/src/main/java/com/app/identity/TokenUtil.java
@@ -17,7 +17,7 @@ public class TokenUtil {
     private static final long VALIDITY_TIME_MS =  2 * 60 * 60 * 1000; // 2 hours  validity
     private static final String AUTH_HEADER_NAME = "Authorization";
 
-    private String secret="mrin";
+    private String secret = UUID.randomUUID().toString();
 
     public Optional<Authentication> verifyToken(HttpServletRequest request) {
       final String token = request.getHeader(AUTH_HEADER_NAME);


### PR DESCRIPTION
Setting the JWT signing key to `small-sized` `easily guessable` weak string like **""mrin""**  can make it vulnerable to offline brute-force attack using cracking tools like [JohnTheRipper](https://github.com/magnumripper/JohnTheRipper), [hashcat](https://github.com/hashcat/hashcat), 
[c-jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker) [1] 

Therefore, the JWT signing key must be [2]
- at least 128 bits (16 characters long)
- cryptographically produced random string having high entropy

I have set the JWT signing key to a cryptographically secure random string so that if anyone uses your code for developing an application, then attackers won't be able to guess the secret key of that application. 

References: 
[1] [Weak Token Secret, OWASP JWT cheat-sheet](  https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.html)
[2] [Ensure Cryptographic Keys Have Sufficient Entropy RFC-8725 JSON Web Token Best Current Practices](https://tools.ietf.org/html/rfc8725#section-3.5) 